### PR TITLE
Add HTTP provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "ethereum-ens": "https://github.com/Arachnid/ensjs.git#03c7f5946b2a1064bfef80b7f844bfb966e762da",
     "ipfs-api": "^17.5.0",
-    "semver": "^5.5.0"
+    "semver": "^5.5.0",
+    "got": "^8.3.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ module.exports = (web3, options = {}) => {
   )
 
   const readFileFromApplication = (contentURI, path) => {
-    const [contentProvider, contentLocation] = contentURI.split(':')
+    const [contentProvider, contentLocation] = contentURI.split(/:(.+)/)
 
     if (!contentProvider || !contentLocation) {
       throw new Error(`Invalid content URI (expected format was "<provider>:<identifier>")`)

--- a/src/providers/http.js
+++ b/src/providers/http.js
@@ -1,0 +1,38 @@
+const got = require('got')
+
+module.exports = (opts = {}) => {
+  opts = Object.assign({
+    host: 'http://localhost'
+    port: 4522
+  }, opts)
+
+  return {
+    identifier: 'http',
+
+    /**
+     * Gets the file at `path` from the content URI `host`.
+     *
+     * @param {string} host The content URI host
+     * @param {string} path The path to the file
+     * @return {Promise} A promise that resolves to the contents of the file
+     */
+    getFile (host, path) {
+      return got(`${host}/${path}`)
+        .then((response) => response.body)
+    },
+    /**
+     * Uploads all files from `path` and returns the content URI for those files.
+     *
+     * @param {string} path The path that contains files to upload
+     * @return {Promise} A promise that resolves to the content URI of the files
+     */
+    async uploadFiles (path) {
+      // We won't actually upload files since we will just
+      // assume that files are available on this URL indefinitely.
+      //
+      // This is an OK assumption since this provider should really
+      // only be used for development purposes.
+      return `http:${host}:${port}`
+    }
+  }
+}


### PR DESCRIPTION
This APM provider is only for development purposes (used in `aragon run`).

It makes some assumptions about where files are located on a server. The hostname of the server can be configured, but defaults to localhost on port 4522 (dev converted to numbers lul)

Closes #4 