### PR TITLE
Add getFileStream() to providers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,7 @@ module.exports = (web3, options = {}) => {
     registryAddress: options.ensRegistryAddress
   }
 
-  const getProviderFromURI = (contentURI, path, cb) => {
+  const getProviderFromURI = (contentURI, path) => {
     const [contentProvider, contentLocation] = contentURI.split(/:(.+)/)
 
     if (!contentProvider || !contentLocation) {

--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,7 @@ module.exports = (web3, options = {}) => {
     registryAddress: options.ensRegistryAddress
   }
 
-  const readFileFromApplication = (contentURI, path) => {
+  const getProviderFromURI = (contentURI, path, cb) => {
     const [contentProvider, contentLocation] = contentURI.split(/:(.+)/)
 
     if (!contentProvider || !contentLocation) {
@@ -38,7 +38,17 @@ module.exports = (web3, options = {}) => {
       throw new Error(`The storage provider "${contentProvider}" is not supported`)
     }
 
-    return providers[contentProvider].getFile(contentLocation, path)
+    return { provider: providers[contentProvider], location: contentLocation }
+  }
+
+  const readFileFromApplication = (contentURI, path) => {
+    const { provider, location } = getProviderFromURI(contentURI, path)
+    return provider.getFile(location, path)
+  }
+
+  const readFileStreamFromApplication = (contentURI, path) => {
+    const { provider, location } = getProviderFromURI(contentURI, path)
+    return provider.getFileStream(location, path)
   }
 
   const getApplicationInfo = (contentURI) => {
@@ -77,6 +87,7 @@ module.exports = (web3, options = {}) => {
 
   return {
     getFile: readFileFromApplication,
+    getFileStream: readFileStreamFromApplication,
 
     /**
      * Get the APM repository registry contract for `appId`.

--- a/src/providers/http.js
+++ b/src/providers/http.js
@@ -20,6 +20,18 @@ module.exports = (opts = {}) => {
       return got(`${host}/${path}`)
         .then((response) => response.body)
     },
+
+    /**
+     * Gets the file stream at `path` from the content URI `hash`.
+     *
+     * @param {string} hash The content URI hash
+     * @param {string} path The path to the file
+     * @return {Stream} A stream that resolves to the contents of the file
+     */
+    getFileStream (host, path) {
+      return got.stream(`${host}/${path}`)
+    },
+
     /**
      * Uploads all files from `path` and returns the content URI for those files.
      *

--- a/src/providers/http.js
+++ b/src/providers/http.js
@@ -26,7 +26,7 @@ module.exports = (opts = {}) => {
      *
      * @param {string} hash The content URI hash
      * @param {string} path The path to the file
-     * @return {Stream} A stream that resolves to the contents of the file
+     * @return {Stream} A stream representing the content of the file
      */
     getFileStream (host, path) {
       return got.stream(`${host}/${path}`)

--- a/src/providers/ipfs.js
+++ b/src/providers/ipfs.js
@@ -17,6 +17,18 @@ module.exports = (opts = {}) => {
       return ipfs.files.cat(`${hash}/${path}`)
         .then((file) => file.toString('utf8'))
     },
+
+    /**
+     * Gets the file stream at `path` from the content URI `hash`.
+     *
+     * @param {string} hash The content URI hash
+     * @param {string} path The path to the file
+     * @return {Stream} A stream that resolves to the contents of the file
+     */
+    getFileStream (hash, path) {
+      return ipfs.files.catReadableStream(`${hash}/${path}`)
+    },
+
     /**
      * Uploads all files from `path` and returns the content URI for those files.
      *

--- a/src/providers/ipfs.js
+++ b/src/providers/ipfs.js
@@ -23,7 +23,7 @@ module.exports = (opts = {}) => {
      *
      * @param {string} hash The content URI hash
      * @param {string} path The path to the file
-     * @return {Stream} A stream that resolves to the contents of the file
+     * @return {Stream} A stream representing the content of the file
      */
     getFileStream (hash, path) {
       return ipfs.files.catReadableStream(`${hash}/${path}`)


### PR DESCRIPTION
So that apm-serve can serve streams directly instead of waiting for the file to be entirely received and converted to a string.

Also the string conversion was causing issues with some files (woff).