### PR TITLE
Use ipfs gateway instead of API when gateway is provided

### DIFF
--- a/src/providers/http.js
+++ b/src/providers/http.js
@@ -1,11 +1,6 @@
 const got = require('got')
 
 module.exports = (opts = {}) => {
-  opts = Object.assign({
-    host: 'http://localhost'
-    port: 4522
-  }, opts)
-
   return {
     identifier: 'http',
 

--- a/src/providers/ipfs.js
+++ b/src/providers/ipfs.js
@@ -1,4 +1,5 @@
 const ipfsAPI = require('ipfs-api')
+const httpProvider = require('./http')()
 
 module.exports = (opts = {}) => {
   const ipfs = ipfsAPI(opts.rpc)
@@ -14,6 +15,10 @@ module.exports = (opts = {}) => {
      * @return {Promise} A promise that resolves to the contents of the file
      */
     getFile (hash, path) {
+      if (opts.gateway) {
+        return httpProvider.getFile(`${opts.gateway}/${hash}`, path)
+      }
+
       return ipfs.files.cat(`${hash}/${path}`)
         .then((file) => file.toString('utf8'))
     },
@@ -26,6 +31,10 @@ module.exports = (opts = {}) => {
      * @return {Stream} A stream representing the content of the file
      */
     getFileStream (hash, path) {
+      if (opts.gateway) {
+        return httpProvider.getFileStream(`${opts.gateway}/${hash}`, path)
+      }
+
       return ipfs.files.catReadableStream(`${hash}/${path}`)
     },
 

--- a/src/providers/ipfs.js
+++ b/src/providers/ipfs.js
@@ -2,7 +2,8 @@ const ipfsAPI = require('ipfs-api')
 const httpProvider = require('./http')()
 
 module.exports = (opts = {}) => {
-  const ipfs = ipfsAPI(opts.rpc)
+  const initIPFS = (rpc) => ipfsAPI(rpc)
+  let ipfs
 
   return {
     identifier: 'ipfs',
@@ -19,6 +20,10 @@ module.exports = (opts = {}) => {
         return httpProvider.getFile(`${opts.gateway}/${hash}`, path)
       }
 
+      if (!ipfs) {
+        ipfs = initIPFS(opts.rpc)
+      }
+
       return ipfs.files.cat(`${hash}/${path}`)
         .then((file) => file.toString('utf8'))
     },
@@ -33,6 +38,10 @@ module.exports = (opts = {}) => {
     getFileStream (hash, path) {
       if (opts.gateway) {
         return httpProvider.getFileStream(`${opts.gateway}/${hash}`, path)
+      }
+
+      if (!ipfs) {
+        ipfs = initIPFS(opts.rpc)
       }
 
       return ipfs.files.catReadableStream(`${hash}/${path}`)


### PR DESCRIPTION
Close #15 

Use http provider with passed IPFS gateway as the host when gateway is provided