### PR TITLE
Fix publishing versions using the HTTP provider

### DIFF
--- a/src/providers/http.js
+++ b/src/providers/http.js
@@ -1,6 +1,6 @@
 const got = require('got')
 
-module.exports = (opts = {}) => {
+module.exports = () => {
   return {
     identifier: 'http',
 
@@ -30,16 +30,16 @@ module.exports = (opts = {}) => {
     /**
      * Uploads all files from `path` and returns the content URI for those files.
      *
-     * @param {string} path The path that contains files to upload
+     * @param {string} url The url where the content will be served
      * @return {Promise} A promise that resolves to the content URI of the files
      */
-    async uploadFiles (path) {
+    async uploadFiles (url) {
       // We won't actually upload files since we will just
       // assume that files are available on this URL indefinitely.
       //
       // This is an OK assumption since this provider should really
       // only be used for development purposes.
-      return `http:${host}:${port}`
+      return `http:${url}`
     }
   }
 }


### PR DESCRIPTION
When publishing a new version, the `uploadFiles(directory)` function is called in the provider. In case of IPFS this makes sense since files need to be added to IPFS, but in case of the HTTP provider it doesn't make sense.

The current design assumed that the host and port of the HTTP server are passed as part of the provider configuration, but the host and port could potentially be specific to every version being published and not a global setting of the apm.js instance.

Now when publishing a version that uses the http provider, the full URL where the content is served can be passed as the 'directory'.