### PR TITLE
chore: update to ipfs-http-client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@aragon/apm",
-  "version": "3.1.0-beta.1",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -14,6 +14,14 @@
         "truffle-flattener": "^1.2.9",
         "truffle-hdwallet-provider": "0.0.3",
         "truffle-hdwallet-provider-privkey": "0.3.0"
+      }
+    },
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "requires": {
+        "event-target-shim": "^5.0.0"
       }
     },
     "abstract-leveldown": {
@@ -53,6 +61,11 @@
         "color-convert": "^1.9.0"
       }
     },
+    "asmcrypto.js": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/asmcrypto.js/-/asmcrypto.js-2.3.2.tgz",
+      "integrity": "sha512-3FgFARf7RupsZETQ1nHnhLUUvpcttcCq1iZCaVAbJZbCZ5VNRrNyvpDyHTOb0KC3llFcsyOT/a99NZcCbeiEsA=="
+    },
     "asn1": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
@@ -62,9 +75,9 @@
       }
     },
     "asn1.js": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.0.1.tgz",
-      "integrity": "sha512-aO8EaEgbgqq77IEw+1jfx5c9zTbzvkfuRBuZsSsPnTHMkmd5AI4J6OtITLZFa381jReeaQL67J0GBTUu0+ZTVw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.2.0.tgz",
+      "integrity": "sha512-Q7hnYGGNYbcmGrCPulXfkEw7oW7qjWeM4ZTALmgpuIcZLxyqqKYWxCZg2UBm8bklrnB4m2mGyJPWfoktdORD8A==",
       "requires": {
         "bn.js": "^4.0.0",
         "inherits": "^2.0.1",
@@ -90,6 +103,20 @@
       "integrity": "sha512-pd20BwL7Yt1zwDFy+8MX8F1+WCT8aQeKj0kQnTrH9WaeRETlRamVhD0JtRPmrV4GfOJ2F9CvdQkZeZhnh2TuHw==",
       "requires": {
         "async": "^2.4.0"
+      }
+    },
+    "async-iterator-all": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-iterator-all/-/async-iterator-all-1.0.0.tgz",
+      "integrity": "sha512-+vC2NFEmAuONF+A2MzM1tUS5pHovDH37/oQbmXW6FgnEns0S9BsR+MJGnzsFHzSN2iFQhbN7L8cFqV1W1F1kpQ=="
+    },
+    "async-iterator-to-pull-stream": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/async-iterator-to-pull-stream/-/async-iterator-to-pull-stream-1.3.0.tgz",
+      "integrity": "sha512-NjyhAEz/sx32olqgKIk/2xbWEM6o8qef1yetIgb0U/R3oBgndP1kE/0CslowH3jvnA94BO4I6OXpOkTKH7Z1AA==",
+      "requires": {
+        "get-iterator": "^1.0.2",
+        "pull-stream-to-async-iterator": "^1.0.1"
       }
     },
     "asynckit": {
@@ -759,6 +786,11 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "base64-js": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+    },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -766,11 +798,6 @@
       "requires": {
         "tweetnacl": "^0.14.3"
       }
-    },
-    "big.js": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
     },
     "bignumber.js": {
       "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
@@ -802,12 +829,36 @@
       }
     },
     "bl": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-2.1.2.tgz",
-      "integrity": "sha512-DvC0x+PxmSJNx8wXoFV15pC2+GOJ3ohb4F1REq3X32a2Z3nEBpR1Guu740M7ouYAImFj4BXDNilLNZbygtG9lQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.0.tgz",
+      "integrity": "sha512-QwQvAZZA1Bw1FWnhNj2X5lu+sPxxB2ITH3mqEqYyahN6JZR13ONjk+XiTnBaGEzMPUrAgOkaD68pBH1rvPRPsw==",
       "requires": {
-        "readable-stream": "^2.3.5",
-        "safe-buffer": "^5.1.1"
+        "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
+        }
       }
     },
     "blakejs": {
@@ -821,20 +872,21 @@
       "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
     },
     "borc": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/borc/-/borc-2.0.4.tgz",
-      "integrity": "sha512-SCVjto/dbKfduyl+LDQ1Km28ly2aTIXtJbrYZWHFQAxkHph96I/zXTrTQXWuJobG8lQZjIA/dw9z7hmJHJhjMg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/borc/-/borc-2.1.1.tgz",
+      "integrity": "sha512-vPLLC2/gS0QN4O3cnPh+8jLshkMMD4qIfs+B1TPGPh30WrtcfItaO6j4k9alsqu/hIgKi8dVdmMvTcbq4tIF7A==",
       "requires": {
-        "bignumber.js": "^7.2.1",
+        "bignumber.js": "^9.0.0",
         "commander": "^2.15.0",
         "ieee754": "^1.1.8",
-        "json-text-sequence": "^0.1"
+        "iso-url": "~0.4.4",
+        "json-text-sequence": "~0.1.0"
       },
       "dependencies": {
         "bignumber.js": {
-          "version": "7.2.1",
-          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
-          "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ=="
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
+          "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
         }
       }
     },
@@ -892,29 +944,14 @@
         "safe-buffer": "^5.1.2"
       }
     },
-    "buffer-alloc": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
-      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+    "buffer": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
+      "integrity": "sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==",
       "requires": {
-        "buffer-alloc-unsafe": "^1.1.0",
-        "buffer-fill": "^1.0.0"
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
       }
-    },
-    "buffer-alloc-unsafe": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
-    },
-    "buffer-fill": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw="
-    },
-    "buffer-from": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
     "buffer-xor": {
       "version": "1.0.3",
@@ -930,6 +967,11 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
+    },
+    "callbackify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/callbackify/-/callbackify-1.1.0.tgz",
+      "integrity": "sha1-0qNphtKKppcUUmwREgm+65l50x4="
     },
     "camelcase": {
       "version": "3.0.0",
@@ -965,13 +1007,13 @@
       }
     },
     "cids": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/cids/-/cids-0.5.5.tgz",
-      "integrity": "sha512-oU8v+N8rViFBcj5KcsXK0gbPiMFHpP/VGlGoWQXZguJsA8ZW0X47fKt0ZPIu03U8CL1Fy+R56tO79urY6MLaSw==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cids/-/cids-0.7.1.tgz",
+      "integrity": "sha512-qEM4j2GKE/BiT6WdUi6cfW8dairhSLTUE8tIdxJG6SvY33Mp/UPjw+xcO0n1zsllgo72BupzKF/44v+Bg8YPPg==",
       "requires": {
         "class-is": "^1.1.0",
-        "multibase": "~0.5.0",
-        "multicodec": "~0.2.7",
+        "multibase": "~0.6.0",
+        "multicodec": "~0.5.1",
         "multihashes": "~0.4.14"
       }
     },
@@ -986,7 +1028,7 @@
     },
     "class-is": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/class-is/-/class-is-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/class-is/-/class-is-1.1.0.tgz",
       "integrity": "sha512-rhjH9AG1fvabIDoGRVH587413LPjTZgmDF9fOFCbFJQV4yuocX1mHxxvXI4g3cGwbVY9wAYIoKlg1N79frJKQw=="
     },
     "cliui": {
@@ -1052,9 +1094,9 @@
       }
     },
     "commander": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
-      "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -1062,14 +1104,36 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "version": "github:hugomrdias/concat-stream#057bc7b5d6d8df26c8cf00a3f151b6721a0a8034",
+      "from": "github:hugomrdias/concat-stream#feat/smaller",
       "requires": {
-        "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
+        "readable-stream": "^3.0.2"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
+        }
       }
     },
     "convert-source-map": {
@@ -1174,6 +1238,11 @@
       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
       "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
     },
+    "delay": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/delay/-/delay-4.3.0.tgz",
+      "integrity": "sha512-Lwaf3zVFDMBop1yDuFZ19F9WyGcZcGacsbdlZtWjQmM50tOcMntm1njF/Nb/Vjij3KaSvCF+sEYGKrrjObu2NA=="
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -1249,12 +1318,17 @@
       }
     },
     "end-of-stream": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "requires": {
         "once": "^1.4.0"
       }
+    },
+    "err-code": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.0.tgz",
+      "integrity": "sha512-MsMOijQ4v0xlmrz1fc7lyPEy7jFhoNF7EVaRSP7mPzs20LaFOwG6qNjGRy3Ie85n9DARlcUnB1zbsBv5sJrIvw=="
     },
     "errno": {
       "version": "0.1.7",
@@ -1358,7 +1432,7 @@
       "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
       "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
       "requires": {
-        "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
+        "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d84a96796079c8595a0c78accd1e7709f2277215",
         "ethereumjs-util": "^5.1.1"
       }
     },
@@ -1376,8 +1450,29 @@
       "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d84a96796079c8595a0c78accd1e7709f2277215",
       "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
       "requires": {
-        "bn.js": "^4.10.0",
-        "ethereumjs-util": "^5.0.0"
+        "bn.js": "^4.11.8",
+        "ethereumjs-util": "^6.0.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+        },
+        "ethereumjs-util": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.1.0.tgz",
+          "integrity": "sha512-URESKMFbDeJxnAxPppnk2fN6Y3BIatn9fwn76Lm8bQlt+s52TpG8dN9M66MLPuRAiAOIqL3dfwqWJf0sd0fL0Q==",
+          "requires": {
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "ethjs-util": "0.1.6",
+            "keccak": "^1.0.2",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1",
+            "secp256k1": "^3.0.1"
+          }
+        }
       }
     },
     "ethereumjs-account": {
@@ -1587,6 +1682,16 @@
         "strip-hex-prefix": "1.0.0"
       }
     },
+    "event-iterator": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/event-iterator/-/event-iterator-1.2.0.tgz",
+      "integrity": "sha512-Daq7YUl0Mv1i4QEgzGQlz0jrx7hUFNyLGbiF+Ap7NCMCjDLCCnolyj6s0TAc6HmrBziO5rNVHsPwGMp7KdRPvw=="
+    },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
+    },
     "events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.0.0.tgz",
@@ -1600,6 +1705,11 @@
         "md5.js": "^1.3.4",
         "safe-buffer": "^5.1.1"
       }
+    },
+    "explain-error": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/explain-error/-/explain-error-1.0.4.tgz",
+      "integrity": "sha1-p5PTrAytTGq1cemWj7urbLJTKSk="
     },
     "extend": {
       "version": "3.0.2",
@@ -1624,6 +1734,11 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
       "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
     },
+    "fast-fifo": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.0.0.tgz",
+      "integrity": "sha512-4VEXmjxLj7sbs8J//cn2qhRap50dGzF5n8fjay8mau+Jn4hxSeR3xPFwxMaQq/pDaq7+KQk0PAbC2+nWDkJrmQ=="
+    },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
@@ -1636,6 +1751,11 @@
       "requires": {
         "node-fetch": "~1.7.1"
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "find-up": {
       "version": "2.1.0",
@@ -1732,6 +1852,11 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
       "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
+    },
+    "get-iterator": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-iterator/-/get-iterator-1.0.2.tgz",
+      "integrity": "sha512-v+dm9bNVfOYsY1OrhaCrmyOcYoSeVvbt+hHZ0Au+T+p1y+0Uyj9aMaGIeUTT6xdpRbWzDeYKvfOslPhggQMcsg=="
     },
     "getpass": {
       "version": "0.1.7",
@@ -1841,6 +1966,11 @@
         "secp256k1": "^3.0.1"
       }
     },
+    "hi-base32": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/hi-base32/-/hi-base32-0.5.0.tgz",
+      "integrity": "sha512-DDRmxSyoYuvjUb9EnXdoiMChBZ7ZcUVJsK5Frd3kqMhuBxvmZdnBeynAVfj7/ECbn++CekcoprvC/rprHPAtow=="
+    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -1904,9 +2034,9 @@
       }
     },
     "ieee754": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
-      "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA=="
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
     },
     "immediate": {
       "version": "3.2.3",
@@ -1945,154 +2075,283 @@
       "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
       "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
     },
-    "ip-address": {
-      "version": "5.8.9",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-5.8.9.tgz",
-      "integrity": "sha512-7ay355oMN34iXhET1BmCJVsHjOTSItEEIIpOs38qUC23AIhOy+xIPnkrTuEFjeLMrTJ7m8KMXWgWfy/2Vn9sDw==",
+    "ip-regex": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
+      "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk="
+    },
+    "ipfs-block": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/ipfs-block/-/ipfs-block-0.8.1.tgz",
+      "integrity": "sha512-0FaCpmij+jZBoUYhjoB5ptjdl9QzvrdRIoBmUU5JiBnK2GA+4YM/ifklaB8ePRhA/rRzhd+KYBjvMFMAL4NrVQ==",
       "requires": {
-        "jsbn": "1.1.0",
-        "lodash.find": "^4.6.0",
-        "lodash.max": "^4.0.1",
-        "lodash.merge": "^4.6.0",
-        "lodash.padstart": "^4.6.1",
-        "lodash.repeat": "^4.1.0",
-        "sprintf-js": "1.1.0"
-      },
-      "dependencies": {
-        "jsbn": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-          "integrity": "sha1-sBMHyym2GKHtJux56RH4A8TaAEA="
-        }
+        "cids": "~0.7.0",
+        "class-is": "^1.1.0"
       }
     },
-    "ipfs-api": {
-      "version": "26.1.2",
-      "resolved": "https://registry.npmjs.org/ipfs-api/-/ipfs-api-26.1.2.tgz",
-      "integrity": "sha512-HkM6vQOHL9z9ZCXIrbDXvAOsIzfWPaAac9kY+SjUuVqMydWHzP8qTxfv5jaXResGbmLcbwcROhuqgJU+HrclSg==",
+    "ipfs-http-client": {
+      "version": "39.0.2",
+      "resolved": "https://registry.npmjs.org/ipfs-http-client/-/ipfs-http-client-39.0.2.tgz",
+      "integrity": "sha512-logfyeSMD2XJCqhKv8hVnSOb/NH2KDECoLeAkwIjWMYK9Yd7eqci0ZDLP4qed0wZ91GFJ09qgCO+6J8ApKrAaQ==",
       "requires": {
+        "abort-controller": "^3.0.0",
         "async": "^2.6.1",
-        "big.js": "^5.2.2",
-        "bl": "^2.1.2",
+        "async-iterator-all": "^1.0.0",
+        "async-iterator-to-pull-stream": "^1.3.0",
+        "bignumber.js": "^9.0.0",
+        "bl": "^4.0.0",
         "bs58": "^4.0.1",
-        "cids": "~0.5.5",
-        "concat-stream": "^1.6.2",
+        "buffer": "^5.4.2",
+        "callbackify": "^1.1.0",
+        "cids": "~0.7.1",
+        "concat-stream": "github:hugomrdias/concat-stream#057bc7b5d6d8df26c8cf00a3f151b6721a0a8034",
         "debug": "^4.1.0",
+        "delay": "^4.3.0",
         "detect-node": "^2.0.4",
         "end-of-stream": "^1.4.1",
+        "err-code": "^2.0.0",
+        "event-iterator": "^1.2.0",
+        "explain-error": "^1.0.4",
         "flatmap": "0.0.3",
+        "form-data": "^2.5.1",
+        "fs-extra": "^8.1.0",
         "glob": "^7.1.3",
-        "ipfs-block": "~0.8.0",
-        "ipfs-unixfs": "~0.1.16",
-        "ipld-dag-cbor": "~0.13.0",
-        "ipld-dag-pb": "~0.14.11",
-        "is-ipfs": "~0.4.7",
+        "ipfs-block": "~0.8.1",
+        "ipfs-utils": "^0.4.0",
+        "ipld-dag-cbor": "~0.15.0",
+        "ipld-dag-pb": "^0.18.1",
+        "ipld-raw": "^4.0.0",
+        "is-ipfs": "~0.6.1",
         "is-pull-stream": "0.0.0",
-        "is-stream": "^1.1.0",
-        "libp2p-crypto": "~0.14.0",
-        "lodash": "^4.17.11",
-        "lru-cache": "^4.1.3",
-        "multiaddr": "^5.0.0",
-        "multibase": "~0.5.0",
+        "is-stream": "^2.0.0",
+        "iso-stream-http": "~0.1.2",
+        "iso-url": "~0.4.6",
+        "it-glob": "0.0.6",
+        "it-to-stream": "^0.1.1",
+        "iterable-ndjson": "^1.1.0",
+        "just-kebab-case": "^1.1.0",
+        "just-map-keys": "^1.1.0",
+        "kind-of": "^6.0.2",
+        "ky": "^0.15.0",
+        "ky-universal": "^0.3.0",
+        "lru-cache": "^5.1.1",
+        "merge-options": "^2.0.0",
+        "multiaddr": "^6.0.6",
+        "multibase": "~0.6.0",
+        "multicodec": "~0.5.1",
         "multihashes": "~0.4.14",
-        "ndjson": "^1.5.0",
+        "ndjson": "github:hugomrdias/ndjson#4db16da6b42e5b39bf300c3a7cde62abb3fa3a11",
         "once": "^1.4.0",
-        "peer-id": "~0.12.0",
-        "peer-info": "~0.14.1",
+        "peer-id": "~0.12.3",
+        "peer-info": "~0.15.1",
+        "promise-nodeify": "^3.0.1",
         "promisify-es6": "^1.0.3",
         "pull-defer": "~0.2.3",
-        "pull-pushable": "^2.2.0",
-        "pull-stream-to-stream": "^1.3.4",
+        "pull-stream": "^3.6.9",
+        "pull-stream-to-async-iterator": "^1.0.2",
+        "pull-to-stream": "~0.1.1",
         "pump": "^3.0.0",
         "qs": "^6.5.2",
-        "readable-stream": "^3.0.6",
-        "stream-http": "^3.0.0",
+        "readable-stream": "^3.1.1",
         "stream-to-pull-stream": "^1.7.2",
-        "streamifier": "~0.1.1",
-        "tar-stream": "^1.6.2",
-        "through2": "^2.0.3"
+        "tar-stream": "^2.0.1",
+        "through2": "^3.0.1"
       },
       "dependencies": {
+        "bignumber.js": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
+          "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
+        },
         "debug": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
-          "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "requires": {
             "ms": "^2.1.1"
           }
         },
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        "form-data": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+          "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+          "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
+        },
+        "is-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
         },
         "readable-stream": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.0.6.tgz",
-          "integrity": "sha512-9E1oLoOWfhSXHGv6QlwXJim7uNzd9EVlWK+21tCU9Ju/kR0/p2AZYPz4qSchgO8PlLIH4FpZYfzwS+rEksZjIg==",
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
             "util-deprecate": "^1.0.1"
           }
         },
+        "safe-buffer": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+        },
         "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "~5.2.0"
           }
         }
       }
     },
-    "ipfs-block": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/ipfs-block/-/ipfs-block-0.8.0.tgz",
-      "integrity": "sha512-znNtFRxXlJYP1/Q4u0tGFJUceH9pNww8WA+zair6T3y7d28m+vtUDJGn96M7ZlFFSkByQyQsAiq2ssNhKtMzxw==",
+    "ipfs-utils": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-0.4.0.tgz",
+      "integrity": "sha512-JLFmCcA058knmYiSB+WBw6nxcDHFS6p05weQOTFR/edufYot0UpgsJTcoMd1fHMq81n0nciJ3QQBqLcJxqGqhA==",
       "requires": {
-        "cids": "~0.5.5",
-        "class-is": "^1.1.0"
-      }
-    },
-    "ipfs-unixfs": {
-      "version": "0.1.16",
-      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-0.1.16.tgz",
-      "integrity": "sha512-TX9Dyu77MxpLzGh/LcQne95TofOyvOeW0oOi72aBMMcV1ItP3684e6NTG9KY1qzdrC+ZUR8kT7y18J058n8KXg==",
-      "requires": {
-        "protons": "^1.0.1"
+        "buffer": "^5.2.1",
+        "err-code": "^2.0.0",
+        "fs-extra": "^8.1.0",
+        "is-buffer": "^2.0.3",
+        "is-electron": "^2.2.0",
+        "is-pull-stream": "0.0.0",
+        "is-stream": "^2.0.0",
+        "it-glob": "0.0.4",
+        "kind-of": "^6.0.2",
+        "pull-stream-to-async-iterator": "^1.0.2",
+        "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+          "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
+        },
+        "is-buffer": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
+        },
+        "is-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
+        },
+        "it-glob": {
+          "version": "0.0.4",
+          "resolved": "https://registry.npmjs.org/it-glob/-/it-glob-0.0.4.tgz",
+          "integrity": "sha512-sTMM62VQWRqlMpgbd+x1uTviQY7a8vMLXYmw+KPiV9vmAYuyIr9Sp1QRQ5B/faybf4O9RzMGyQb7eFpqLwsBhQ==",
+          "requires": {
+            "fs-extra": "^8.1.0",
+            "minimatch": "^3.0.4"
+          }
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
+        "readable-stream": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
+        }
       }
     },
     "ipld-dag-cbor": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/ipld-dag-cbor/-/ipld-dag-cbor-0.13.0.tgz",
-      "integrity": "sha512-74gtitUOWbLkGtqomhq7lDYwWzfFNwbwMXAj3jpti4ZtfM9VTJWVIQ+05u7NOCj8yaLwzFONHdcO0rJ+j/i0jA==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/ipld-dag-cbor/-/ipld-dag-cbor-0.15.0.tgz",
+      "integrity": "sha512-wc9nrDtV4Le76UUhG4LXX57NVi5d7JS2kLid2nOYZAcr0SFhiXZL2ZyV3bfmNohO50KvgPEessSaBBSm9bflGA==",
       "requires": {
-        "async": "^2.6.1",
-        "borc": "^2.0.3",
-        "bs58": "^4.0.1",
-        "cids": "~0.5.5",
+        "borc": "^2.1.0",
+        "cids": "~0.7.0",
         "is-circular": "^1.0.2",
-        "multihashes": "~0.4.14",
-        "multihashing-async": "~0.5.1",
-        "traverse": "~0.6.6"
+        "multicodec": "~0.5.0",
+        "multihashing-async": "~0.7.0"
       }
     },
     "ipld-dag-pb": {
-      "version": "0.14.11",
-      "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.14.11.tgz",
-      "integrity": "sha512-ja4FH6elDprVuJBkNObFlq7+9h1Q3aoQx5SSG/v3I9e7j19nwyuMhLJYwBhdv29LiqpyD2cEqNrJLm8lWn0lJg==",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.18.1.tgz",
+      "integrity": "sha512-YU2k7kfhV9uliVCAdIyJkYnTLNMdc4FyM2q2dZjfvegdzJFw5Ts8IHnMU77CCLIyD2cc/3xvf9dLIzMIBZpV1A==",
       "requires": {
-        "async": "^2.6.1",
-        "bs58": "^4.0.1",
-        "cids": "~0.5.4",
+        "cids": "~0.7.1",
         "class-is": "^1.1.0",
-        "is-ipfs": "~0.4.2",
-        "multihashing-async": "~0.5.1",
+        "multicodec": "~0.5.5",
+        "multihashing-async": "~0.7.0",
         "protons": "^1.0.1",
-        "pull-stream": "^3.6.9",
-        "pull-traverse": "^1.0.3",
         "stable": "~0.1.8"
+      }
+    },
+    "ipld-raw": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ipld-raw/-/ipld-raw-4.0.0.tgz",
+      "integrity": "sha512-yNQG5zQqm/RH8aNQxcvcsAdHJW4q+LJ3cPfFzHOtujEa/PRlT5YCOVpAFh61HfpsWFm2GJrb2G+HHgtDDlFSMw==",
+      "requires": {
+        "cids": "~0.7.0",
+        "multicodec": "~0.5.0",
+        "multihashing-async": "~0.7.0"
       }
     },
     "is-arrayish": {
@@ -2128,6 +2387,11 @@
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
       "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
     },
+    "is-electron": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.0.tgz",
+      "integrity": "sha512-SpMppC2XR3YdxSzczXReBjqs2zGscWQpBIKqwXYBFic0ERaxNVgwLCHwOLZeESfdJQjX0RDvrJ1lBXX2ij+G1Q=="
+    },
     "is-finite": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
@@ -2159,26 +2423,31 @@
       "resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
       "integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ="
     },
-    "is-ipfs": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/is-ipfs/-/is-ipfs-0.4.7.tgz",
-      "integrity": "sha512-u+LzRRA5s2XMJnQ65R60SvRKb8R04ZITbbRMWBESLyLPlJ+J78zaXZzNZBIf4SQ0pnWioMNCpiIV4hw098MgOQ==",
+    "is-ip": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-2.0.0.tgz",
+      "integrity": "sha1-aO6gfooKCpTC0IDdZ0xzGrKkYas=",
       "requires": {
-        "bs58": "4.0.1",
-        "cids": "~0.5.5",
-        "multibase": "~0.4.0",
-        "multihashes": "~0.4.13"
-      },
-      "dependencies": {
-        "multibase": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.4.0.tgz",
-          "integrity": "sha512-fnYvZJWDn3eSJ7EeWvS8zbOpRwuyPHpDggSnqGXkQMvYED5NdO9nyqnZboGvAT+r/60J8KZ09tW8YJHkS22sFw==",
-          "requires": {
-            "base-x": "3.0.4"
-          }
-        }
+        "ip-regex": "^2.0.0"
       }
+    },
+    "is-ipfs": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/is-ipfs/-/is-ipfs-0.6.1.tgz",
+      "integrity": "sha512-WhqQylam6pODS2RyqT/u0PR5KWtBZNCgPjgargFOVQjzw/3+6d0midXenzU65klM4LH13IUiCC6ObhDUdXZ7Nw==",
+      "requires": {
+        "bs58": "^4.0.1",
+        "cids": "~0.7.0",
+        "mafmt": "^6.0.7",
+        "multiaddr": "^6.0.4",
+        "multibase": "~0.6.0",
+        "multihashes": "~0.4.13"
+      }
+    },
+    "is-plain-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.0.0.tgz",
+      "integrity": "sha512-EYisGhpgSCwspmIuRHGjROWTon2Xp8Z7U03Wubk/bTL5TTRC5R1rGVgyjzBrk9+ULdH6cRD06KRcw/xfqhVYKQ=="
     },
     "is-promise": {
       "version": "1.0.1",
@@ -2226,10 +2495,79 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
       "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
     },
-    "isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+    "iso-random-stream": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/iso-random-stream/-/iso-random-stream-1.1.1.tgz",
+      "integrity": "sha512-YEt/7xOwTdu4KXIgtdgGFkiLUsBaddbnkmHyaFdjJYIcD7V4gpQHPvYC5tyh3kA0PQ01y9lWm1ruVdf8Mqzovg==",
+      "requires": {
+        "buffer": "^5.4.3",
+        "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
+        }
+      }
+    },
+    "iso-stream-http": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/iso-stream-http/-/iso-stream-http-0.1.2.tgz",
+      "integrity": "sha512-oHEDNOysIMTNypbg2f1SlydqRBvjl4ZbSE9+0awVxnkx3K2stGTFwB/kpVqnB6UEfF8QD36kAjDwZvqyXBLMnQ==",
+      "requires": {
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^3.1.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
+        }
+      }
+    },
+    "iso-url": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-0.4.6.tgz",
+      "integrity": "sha512-YQO7+aIe6l1aSJUKOx+Vrv08DlhZeLFIVfehG2L29KLSEb9RszqPXilxJRVpp57px36BddKR5ZsebacO5qG0tg=="
     },
     "isomorphic-fetch": {
       "version": "2.2.1",
@@ -2244,6 +2582,101 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "it-glob": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/it-glob/-/it-glob-0.0.6.tgz",
+      "integrity": "sha512-B2FsVvjP/iDzHIph3g9oSeqwOwTfcxuuiKSC7U78/AIWKbBzM8tyVZAEIgOjMOQDNMqCBUD2MNedt0gSIOJU8w==",
+      "requires": {
+        "fs-extra": "^8.1.0",
+        "minimatch": "^3.0.4"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+          "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        }
+      }
+    },
+    "it-to-stream": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/it-to-stream/-/it-to-stream-0.1.1.tgz",
+      "integrity": "sha512-QQx/58JBvT189imr6fD234F8aVf8EdyQHJR0MxXAOShEWK1NWyahPYIQt/tQG7PId0ZG/6/3tUiVCfw2cq+e1w==",
+      "requires": {
+        "buffer": "^5.2.1",
+        "fast-fifo": "^1.0.0",
+        "get-iterator": "^1.0.2",
+        "p-defer": "^3.0.0",
+        "p-fifo": "^1.0.0",
+        "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
+        }
+      }
+    },
+    "iterable-ndjson": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/iterable-ndjson/-/iterable-ndjson-1.1.0.tgz",
+      "integrity": "sha512-OOp1Lb0o3k5MkXHx1YaIY5Z0ELosZfTnBaas9f8opJVcZGBIONA2zY/6CYE+LKkqrSDooIneZbrBGgOZnHPkrg==",
+      "requires": {
+        "string_decoder": "^1.2.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
+        }
+      }
     },
     "js-sha3": {
       "version": "0.5.5",
@@ -2351,6 +2784,16 @@
         "verror": "1.10.0"
       }
     },
+    "just-kebab-case": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/just-kebab-case/-/just-kebab-case-1.1.0.tgz",
+      "integrity": "sha512-QkuwuBMQ9BQHMUEkAtIA4INLrkmnnveqlFB1oFi09gbU0wBdZo6tTnyxNWMR84zHxBuwK7GLAwqN8nrvVxOLTA=="
+    },
+    "just-map-keys": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/just-map-keys/-/just-map-keys-1.1.0.tgz",
+      "integrity": "sha512-oNKi+4y7fr8lXnhKYpBbCkiwHRVkAnx0VDkCeTDtKKMzGr1Lz1Yym+RSieKUTKim68emC5Yxrb4YmiF9STDO+g=="
+    },
     "keccak": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
@@ -2367,12 +2810,38 @@
       "resolved": "https://registry.npmjs.org/keypair/-/keypair-1.0.1.tgz",
       "integrity": "sha1-dgNxknCvtlZO04oiCHoG/Jqk6hs="
     },
+    "kind-of": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+    },
     "klaw": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
       "requires": {
         "graceful-fs": "^4.1.9"
+      }
+    },
+    "ky": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/ky/-/ky-0.15.0.tgz",
+      "integrity": "sha512-6IlJRPFHq4ZKRRa9lyh6YqHqlmddAkfyXI9CYvZpLQtg7fQvwncPHyHrmtXAHKCqHOilINPMT88eW6FTA3HwkA=="
+    },
+    "ky-universal": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/ky-universal/-/ky-universal-0.3.0.tgz",
+      "integrity": "sha512-CM4Bgb2zZZpsprcjI6DNYTaH3oGHXL2u7BU4DK+lfCuC4snkt9/WRpMYeKbBbXscvKkeqBwzzjFX2WwmKY5K/A==",
+      "requires": {
+        "abort-controller": "^3.0.0",
+        "node-fetch": "^2.6.0"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+        }
       }
     },
     "lcid": {
@@ -2472,61 +2941,131 @@
       }
     },
     "libp2p-crypto": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.14.1.tgz",
-      "integrity": "sha512-JP3bfEzNik76fFIWOeU909+v76tjj5BMukbPCc61bgh1ixftcHkr4bH79duz+oSxRpGA+orCLxvkhgALV+pfwg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.16.3.tgz",
+      "integrity": "sha512-ro7/5Tu+f8p2+qDS1JrROnO++nNaAaBFs+VVXVHLuTMnbnMASu1eUtSlWPk1uOwikAlBFTvfqe5J1bK6Bpq6Pg==",
       "requires": {
+        "asmcrypto.js": "^2.3.2",
         "asn1.js": "^5.0.1",
         "async": "^2.6.1",
+        "bn.js": "^4.11.8",
         "browserify-aes": "^1.2.0",
         "bs58": "^4.0.1",
+        "iso-random-stream": "^1.1.0",
         "keypair": "^1.0.1",
-        "libp2p-crypto-secp256k1": "~0.2.2",
+        "libp2p-crypto-secp256k1": "~0.3.0",
         "multihashing-async": "~0.5.1",
-        "node-forge": "~0.7.6",
-        "pem-jwk": "^1.5.1",
+        "node-forge": "~0.9.1",
+        "pem-jwk": "^2.0.0",
         "protons": "^1.0.1",
         "rsa-pem-to-jwk": "^1.1.3",
         "tweetnacl": "^1.0.0",
-        "ursa-optional": "~0.9.9",
-        "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#master"
+        "ursa-optional": "~0.10.0"
       },
       "dependencies": {
+        "bn.js": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+        },
+        "js-sha3": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+          "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+        },
+        "multihashing-async": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.5.2.tgz",
+          "integrity": "sha512-mmyG6M/FKxrpBh9xQDUvuJ7BbqT93ZeEeH5X6LeMYKoYshYLr9BDdCsvDtZvn+Egf+/Xi+aOznrWL4vp3s+p0Q==",
+          "requires": {
+            "blakejs": "^1.1.0",
+            "js-sha3": "~0.8.0",
+            "multihashes": "~0.4.13",
+            "murmurhash3js": "^3.0.1",
+            "nodeify": "^1.0.1"
+          }
+        },
         "tweetnacl": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
-          "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins="
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.1.tgz",
+          "integrity": "sha512-kcoMoKTPYnoeS50tzoqjPY3Uv9axeuuFAZY9M/9zFnhoVvRfxz9K29IMPD7jGmt2c8SW7i3gT9WqDl2+nV7p4A=="
         }
       }
     },
     "libp2p-crypto-secp256k1": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/libp2p-crypto-secp256k1/-/libp2p-crypto-secp256k1-0.2.2.tgz",
-      "integrity": "sha1-DdUh8Yq8TjahUuJOmzYwewrpzwU=",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/libp2p-crypto-secp256k1/-/libp2p-crypto-secp256k1-0.3.1.tgz",
+      "integrity": "sha512-evrfK/CeUSd/lcELUdDruyPBvxDmLairth75S32OLl3H+++2m2fV24JEtxzdFS9JH3xEFw0h6JFO8DBa1bP9dA==",
       "requires": {
-        "async": "^2.5.0",
-        "multihashing-async": "~0.4.6",
+        "async": "^2.6.2",
+        "bs58": "^4.0.1",
+        "multihashing-async": "~0.6.0",
         "nodeify": "^1.0.1",
-        "safe-buffer": "^5.1.1",
-        "secp256k1": "^3.3.0"
+        "safe-buffer": "^5.1.2",
+        "secp256k1": "^3.6.2"
       },
       "dependencies": {
+        "async": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+          "requires": {
+            "lodash": "^4.17.14"
+          }
+        },
+        "bindings": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+          "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+          "requires": {
+            "file-uri-to-path": "1.0.0"
+          }
+        },
+        "bn.js": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+        },
         "js-sha3": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.7.0.tgz",
-          "integrity": "sha512-Wpks3yBDm0UcL5qlVhwW9Jr9n9i4FfeWBFOOXP5puDS/SiudJGhw7DPyBqn3487qD4F0lsC0q3zxink37f7zeA=="
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+          "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
         },
         "multihashing-async": {
-          "version": "0.4.8",
-          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
-          "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.6.0.tgz",
+          "integrity": "sha512-Qv8pgg99Lewc191A5nlXy0bSd2amfqlafNJZmarU6Sj7MZVjpR94SCxQjf4DwPtgWZkiLqsjUQBXA2RSq+hYyA==",
           "requires": {
-            "async": "^2.6.0",
             "blakejs": "^1.1.0",
-            "js-sha3": "^0.7.0",
+            "js-sha3": "~0.8.0",
             "multihashes": "~0.4.13",
             "murmurhash3js": "^3.0.1",
             "nodeify": "^1.0.1"
+          }
+        },
+        "nan": {
+          "version": "2.14.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+          "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+        },
+        "secp256k1": {
+          "version": "3.7.1",
+          "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.7.1.tgz",
+          "integrity": "sha512-1cf8sbnRreXrQFdH6qsg2H71Xw91fCCS9Yp021GnUNJzWJS/py96fS4lHbnTnouLp08Xj6jBoBB6V78Tdbdu5g==",
+          "requires": {
+            "bindings": "^1.5.0",
+            "bip66": "^1.1.5",
+            "bn.js": "^4.11.8",
+            "create-hash": "^1.2.0",
+            "drbg.js": "^1.0.1",
+            "elliptic": "^6.4.1",
+            "nan": "^2.14.0",
+            "safe-buffer": "^5.1.2"
           }
         }
       }
@@ -2562,46 +3101,6 @@
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
       "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
     },
-    "lodash.filter": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
-      "integrity": "sha1-ZosdSYFgOuHMWm+nYBQ+SAtMSs4="
-    },
-    "lodash.find": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-4.6.0.tgz",
-      "integrity": "sha1-ywcE1Hq3F4n/oN6Ll92Sb7iLE7E="
-    },
-    "lodash.map": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
-      "integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM="
-    },
-    "lodash.max": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.max/-/lodash.max-4.0.1.tgz",
-      "integrity": "sha1-hzVWbGGLNan3YFILSHrnllivE2o="
-    },
-    "lodash.merge": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
-      "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ=="
-    },
-    "lodash.padstart": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz",
-      "integrity": "sha1-0uPuv/DZ05rVD1y9G1KnvOa7YRs="
-    },
-    "lodash.repeat": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-4.1.0.tgz",
-      "integrity": "sha1-/H3oEx2MisB+S0n3T/6CnR8r7EQ="
-    },
-    "lodash.uniqby": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
-      "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI="
-    },
     "looper": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/looper/-/looper-3.0.0.tgz",
@@ -2616,12 +3115,11 @@
       }
     },
     "lru-cache": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
-      "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "requires": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
+        "yallist": "^3.0.2"
       }
     },
     "ltgt": {
@@ -2630,11 +3128,11 @@
       "integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU="
     },
     "mafmt": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/mafmt/-/mafmt-6.0.2.tgz",
-      "integrity": "sha512-+ydrVDp/bo2GPTNN0378AFX66IJBlbrIBY0RaILWC9AICr9kviX5fonHeKsZiesEuuYetQeRhnZPL/J2k8vHAA==",
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/mafmt/-/mafmt-6.0.10.tgz",
+      "integrity": "sha512-FjHDnew6dW9lUu3eYwP0FvvJl9uvNbqfoJM+c1WJcSyutNEIlyu6v3f/rlPnD1cnmue38IjuHlhBdIh3btAiyw==",
       "requires": {
-        "multiaddr": "^5.0.0"
+        "multiaddr": "^6.1.0"
       }
     },
     "md5.js": {
@@ -2674,6 +3172,14 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
       "integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI="
+    },
+    "merge-options": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-2.0.0.tgz",
+      "integrity": "sha512-S7xYIeWHl2ZUKF7SDeBhGg6rfv5bKxVBdk95s/I7wVF8d+hjLSztJ/B271cnUiF6CAFduEQ5Zn3HYwAjT16DlQ==",
+      "requires": {
+        "is-plain-obj": "^2.0.0"
+      }
     },
     "merkle-patricia-tree": {
       "version": "2.3.2",
@@ -2755,62 +3261,65 @@
       "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
     },
     "multiaddr": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-5.0.2.tgz",
-      "integrity": "sha512-dXz1chaUHV6L6okujDLS7uRA6NmCbitpikOJA0vMMnrwVyai5kC3ot2CSLrSfj3B8XIgNzpe/j5auSYrnbGGzA==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-6.1.1.tgz",
+      "integrity": "sha512-Q1Ika0F9MNhMtCs62Ue+GWIJtRFEhZ3Xz8wH7/MZDVZTWhil1/H2bEGN02kUees3hkI3q1oHSjmXYDM0gxaFjQ==",
       "requires": {
         "bs58": "^4.0.1",
         "class-is": "^1.1.0",
+        "hi-base32": "~0.5.0",
         "ip": "^1.1.5",
-        "ip-address": "^5.8.9",
-        "lodash.filter": "^4.6.0",
-        "lodash.map": "^4.6.0",
-        "varint": "^5.0.0",
-        "xtend": "^4.0.1"
+        "is-ip": "^2.0.0",
+        "varint": "^5.0.0"
       }
     },
     "multibase": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.5.0.tgz",
-      "integrity": "sha512-7epKiK8/UBzraYZvOuZa8FH/00hMfTnzTy1OQol1YBU2csAYA7rwWh+iue9plXRmVFBGvmVKMuo0oq5sD47kvw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.6.0.tgz",
+      "integrity": "sha512-R9bNLQhbD7MsitPm1NeY7w9sDgu6d7cuj25snAWH7k5PSNPSwIQQBpcpj8jx1W96dLbdigZqmUWOdQRMnAmgjA==",
       "requires": {
         "base-x": "3.0.4"
       }
     },
     "multicodec": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-0.2.7.tgz",
-      "integrity": "sha512-96xc9zs7bsclMW0Po9ERnRFqcsWHY8OZ8JW/I8DeHG58YYJZy3cBGI00Ze7hz9Ix56DNHMTSxEj9cgoZByruMg==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-0.5.5.tgz",
+      "integrity": "sha512-1kOifvwAqp9IdiiTKmpK2tS+LY6GHZdKpk3S2EvW4T32vlwDyA3hJoZtGauzqdedUPVNGChnTksEotVOCVlC+Q==",
       "requires": {
         "varint": "^5.0.0"
       }
     },
     "multihashes": {
-      "version": "0.4.14",
-      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.14.tgz",
-      "integrity": "sha512-V/g/EIN6nALXfS/xHUAgtfPP3mn3sPIF/i9beuGKf25QXS2QZYCpeVJbDPEannkz32B2fihzCe2D/KMrbcmefg==",
+      "version": "0.4.15",
+      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.15.tgz",
+      "integrity": "sha512-G/Smj1GWqw1RQP3dRuRRPe3oyLqvPqUaEDIaoi7JF7Loxl4WAWvhJNk84oyDEodSucv0MmSW/ZT0RKUrsIFD3g==",
       "requires": {
         "bs58": "^4.0.1",
         "varint": "^5.0.0"
       }
     },
     "multihashing-async": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.5.1.tgz",
-      "integrity": "sha512-Ft5lQNcJCfsns1QN1TDXqPZrrNwBYqIokprYJR2h2Jj01x0GFcYmJYAqHvme6vJoyI3XptEcmZpdr9g5Oy7q3Q==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.7.0.tgz",
+      "integrity": "sha512-SCbfl3f+DzJh+/5piukga9ofIOxwfT05t8R4jfzZIJ88YE9zU9+l3K2X+XB19MYyxqvyK9UJRNWbmQpZqQlbRA==",
       "requires": {
-        "async": "^2.6.1",
         "blakejs": "^1.1.0",
-        "js-sha3": "^0.7.0",
+        "buffer": "^5.2.1",
+        "err-code": "^1.1.2",
+        "js-sha3": "~0.8.0",
         "multihashes": "~0.4.13",
-        "murmurhash3js": "^3.0.1",
-        "nodeify": "^1.0.1"
+        "murmurhash3js-revisited": "^3.0.0"
       },
       "dependencies": {
+        "err-code": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
+          "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA="
+        },
         "js-sha3": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.7.0.tgz",
-          "integrity": "sha512-Wpks3yBDm0UcL5qlVhwW9Jr9n9i4FfeWBFOOXP5puDS/SiudJGhw7DPyBqn3487qD4F0lsC0q3zxink37f7zeA=="
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+          "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
         }
       }
     },
@@ -2819,25 +3328,29 @@
       "resolved": "https://registry.npmjs.org/murmurhash3js/-/murmurhash3js-3.0.1.tgz",
       "integrity": "sha1-Ppg+W0fCoG9DpxMXTn5DXKBEuZg="
     },
+    "murmurhash3js-revisited": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/murmurhash3js-revisited/-/murmurhash3js-revisited-3.0.0.tgz",
+      "integrity": "sha512-/sF3ee6zvScXMb1XFJ8gDsSnY+X8PbOyjIuBhtgis10W2Jx4ZjIhikUCIF9c4gpJxVnQIsPAFrSwTCuAjicP6g=="
+    },
     "nan": {
       "version": "2.11.1",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
       "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA=="
     },
     "ndjson": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/ndjson/-/ndjson-1.5.0.tgz",
-      "integrity": "sha1-rmA7NrE0vOw0e0UkIrC/mNWDLsg=",
+      "version": "github:hugomrdias/ndjson#4db16da6b42e5b39bf300c3a7cde62abb3fa3a11",
+      "from": "github:hugomrdias/ndjson#feat/readable-stream3",
       "requires": {
         "json-stringify-safe": "^5.0.1",
         "minimist": "^1.2.0",
-        "split2": "^2.1.0",
-        "through2": "^2.0.3"
+        "split2": "^3.1.0",
+        "through2": "^3.0.0"
       },
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
@@ -2852,9 +3365,9 @@
       }
     },
     "node-forge": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.6.tgz",
-      "integrity": "sha512-sol30LUpz1jQFBjOKwbjxijiE3b6pjd74YwfD0fJOKPjF+fONKb2Yg8rYgS6+bK6VDl+/wfr4IYpC7jDzLUIfw=="
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.1.tgz",
+      "integrity": "sha512-G6RlQt5Sb4GMBzXvhfkeFmbqR6MzhtnT7VTHuLadjkii3rdYHNdw0m8zA4BTxVIh68FicCQ2NSUANpsqkr9jvQ=="
     },
     "nodeify": {
       "version": "1.0.1",
@@ -2949,6 +3462,20 @@
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
+    "p-defer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
+      "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="
+    },
+    "p-fifo": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-fifo/-/p-fifo-1.0.0.tgz",
+      "integrity": "sha512-IjoCxXW48tqdtDFz6fqo5q1UfFVjjVZe8TC1QRflvNUJtNfCUhxOUw6MOVZhDPjqhSzc26xKdugsO17gmzd5+A==",
+      "requires": {
+        "fast-fifo": "^1.0.0",
+        "p-defer": "^3.0.0"
+      }
+    },
     "p-limit": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
@@ -3025,188 +3552,48 @@
       }
     },
     "peer-id": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.12.0.tgz",
-      "integrity": "sha512-pPKk4IDBWGGzcjXe6zzngIwKmyadYNsIOUH1PKb7GYTVVTKHpHn78ljZNZdAXAWZ2V1TmlU2OS6d9MfW2E5DNA==",
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.12.5.tgz",
+      "integrity": "sha512-3xVWrtIvNm9/OPzaQBgXDrfWNx63AftgFQkvqO6YSZy7sP3Fuadwwbn54F/VO9AnpyW/26i0WRQz9FScivXrmw==",
       "requires": {
-        "async": "^2.6.1",
+        "async": "^2.6.3",
         "class-is": "^1.1.0",
-        "libp2p-crypto": "~0.13.0",
-        "lodash": "^4.17.10",
-        "multihashes": "~0.4.13"
+        "libp2p-crypto": "~0.16.1",
+        "multihashes": "~0.4.15"
       },
       "dependencies": {
-        "js-sha3": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.7.0.tgz",
-          "integrity": "sha512-Wpks3yBDm0UcL5qlVhwW9Jr9n9i4FfeWBFOOXP5puDS/SiudJGhw7DPyBqn3487qD4F0lsC0q3zxink37f7zeA=="
-        },
-        "libp2p-crypto": {
-          "version": "0.13.0",
-          "resolved": "http://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.13.0.tgz",
-          "integrity": "sha512-i3r1TBec/xYmC5bcpPiIs3OyUAU3iy53OdRdxqawKoWTQPjYB+TyQ4w+otT66Y0sMcw70O0wH3GFAfPmQgFn+g==",
+        "async": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
           "requires": {
-            "asn1.js": "^5.0.0",
-            "async": "^2.6.0",
-            "browserify-aes": "^1.2.0",
-            "bs58": "^4.0.1",
-            "keypair": "^1.0.1",
-            "libp2p-crypto-secp256k1": "~0.2.2",
-            "multihashing-async": "~0.4.8",
-            "node-forge": "^0.7.5",
-            "pem-jwk": "^1.5.1",
-            "protons": "^1.0.1",
-            "rsa-pem-to-jwk": "^1.1.3",
-            "tweetnacl": "^1.0.0",
-            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#master"
-          },
-          "dependencies": {
-            "webcrypto-shim": {
-              "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8",
-              "from": "github:dignifiedquire/webcrypto-shim#master"
-            }
+            "lodash": "^4.17.14"
           }
         },
-        "multihashing-async": {
-          "version": "0.4.8",
-          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
-          "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
-          "requires": {
-            "async": "^2.6.0",
-            "blakejs": "^1.1.0",
-            "js-sha3": "^0.7.0",
-            "multihashes": "~0.4.13",
-            "murmurhash3js": "^3.0.1",
-            "nodeify": "^1.0.1"
-          }
-        },
-        "tweetnacl": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
-          "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins="
-        },
-        "webcrypto-shim": {
-          "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8",
-          "from": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
         }
       }
     },
     "peer-info": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/peer-info/-/peer-info-0.14.1.tgz",
-      "integrity": "sha512-I9K+q7sisU0gg5ej6ekbhgolwlcm1tc2wDtLmumptoLYx0DkIT8WVHtgoTnupYwRRqcYADtwddFdiXfb8QFqzg==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/peer-info/-/peer-info-0.15.1.tgz",
+      "integrity": "sha512-Y91Q2tZRC0CpSTPd1UebhGqniOrOAk/aj60uYUcWJXCoLTAnGu+4LJGoiay8ayudS6ice7l3SKhgL/cS62QacA==",
       "requires": {
-        "lodash.uniqby": "^4.7.0",
-        "mafmt": "^6.0.0",
-        "multiaddr": "^4.0.0",
-        "peer-id": "~0.10.7"
-      },
-      "dependencies": {
-        "js-sha3": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.7.0.tgz",
-          "integrity": "sha512-Wpks3yBDm0UcL5qlVhwW9Jr9n9i4FfeWBFOOXP5puDS/SiudJGhw7DPyBqn3487qD4F0lsC0q3zxink37f7zeA=="
-        },
-        "libp2p-crypto": {
-          "version": "0.12.1",
-          "resolved": "http://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.12.1.tgz",
-          "integrity": "sha512-1/z8rxZ0DcQNreZhEsl7PnLr7DWOioSvYbKBLGkRwNRiNh1JJLgh0PdTySBb44wkrOGT+TxcGRd7iq3/X6Wxwg==",
-          "requires": {
-            "asn1.js": "^5.0.0",
-            "async": "^2.6.0",
-            "browserify-aes": "^1.1.1",
-            "bs58": "^4.0.1",
-            "keypair": "^1.0.1",
-            "libp2p-crypto-secp256k1": "~0.2.2",
-            "multihashing-async": "~0.4.7",
-            "node-forge": "^0.7.1",
-            "pem-jwk": "^1.5.1",
-            "protons": "^1.0.1",
-            "rsa-pem-to-jwk": "^1.1.3",
-            "tweetnacl": "^1.0.0",
-            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#master"
-          },
-          "dependencies": {
-            "webcrypto-shim": {
-              "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8",
-              "from": "github:dignifiedquire/webcrypto-shim#master"
-            }
-          }
-        },
-        "multiaddr": {
-          "version": "4.0.0",
-          "resolved": "http://registry.npmjs.org/multiaddr/-/multiaddr-4.0.0.tgz",
-          "integrity": "sha512-zUatrOCfBd/tJNOSoJ10d2EI2FDXB9PyPZhqUMdXE9mOyR3C+HLuOjga2Ga/eChwvEHIpTYRMoIKF2Nv7af2qQ==",
-          "requires": {
-            "bs58": "^4.0.1",
-            "class-is": "^1.1.0",
-            "ip": "^1.1.5",
-            "ip-address": "^5.8.9",
-            "lodash.filter": "^4.6.0",
-            "lodash.map": "^4.6.0",
-            "varint": "^5.0.0",
-            "xtend": "^4.0.1"
-          }
-        },
-        "multihashing-async": {
-          "version": "0.4.8",
-          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
-          "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
-          "requires": {
-            "async": "^2.6.0",
-            "blakejs": "^1.1.0",
-            "js-sha3": "^0.7.0",
-            "multihashes": "~0.4.13",
-            "murmurhash3js": "^3.0.1",
-            "nodeify": "^1.0.1"
-          }
-        },
-        "peer-id": {
-          "version": "0.10.7",
-          "resolved": "http://registry.npmjs.org/peer-id/-/peer-id-0.10.7.tgz",
-          "integrity": "sha512-VEpMFcL9q0NQijmR0jsj38OGbY4yzaWMEareVkDahopmlNT+Cpsot8btPgsgBBApP9NiZj2Enwvh8rZN30ocQw==",
-          "requires": {
-            "async": "^2.6.0",
-            "libp2p-crypto": "~0.12.1",
-            "lodash": "^4.17.5",
-            "multihashes": "~0.4.13"
-          }
-        },
-        "tweetnacl": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
-          "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins="
-        },
-        "webcrypto-shim": {
-          "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8",
-          "from": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
-        }
+        "mafmt": "^6.0.2",
+        "multiaddr": "^6.0.3",
+        "peer-id": "~0.12.2",
+        "unique-by": "^1.0.0"
       }
     },
     "pem-jwk": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/pem-jwk/-/pem-jwk-1.5.1.tgz",
-      "integrity": "sha1-eoY3/S9nqCflfAxC4cI8P9Us+wE=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pem-jwk/-/pem-jwk-2.0.0.tgz",
+      "integrity": "sha512-rFxu7rVoHgQ5H9YsP50dDWf0rHjreVA2z0yPiWr5WdH/UHb29hKtF7h6l8vNd1cbYR1t0QL+JKhW55a2ZV4KtA==",
       "requires": {
-        "asn1.js": "1.0.3"
-      },
-      "dependencies": {
-        "asn1.js": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
-          "integrity": "sha1-KBuj7B8kSP52X5Kk7s+IP+E2S1Q=",
-          "requires": {
-            "bn.js": "^1.0.0",
-            "inherits": "^2.0.1",
-            "minimalistic-assert": "^1.0.0"
-          }
-        },
-        "bn.js": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz",
-          "integrity": "sha1-DbTL+W+PI7dC9by50ap6mZSgXoM=",
-          "optional": true
-        }
+        "asn1.js": "^5.0.1"
       }
     },
     "performance-now": {
@@ -3249,11 +3636,16 @@
     },
     "promise": {
       "version": "1.3.0",
-      "resolved": "http://registry.npmjs.org/promise/-/promise-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-1.3.0.tgz",
       "integrity": "sha1-5cyaTIJ45GZP/twBx9qEhCsEAXU=",
       "requires": {
         "is-promise": "~1"
       }
+    },
+    "promise-nodeify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/promise-nodeify/-/promise-nodeify-3.0.1.tgz",
+      "integrity": "sha512-ghsSuzZXJX8iO7WVec2z7GI+Xk/EyiD+JZK7AZKhUqYfpLa/Zs4ylUD+CwwnKlG6G3HnkUPMAi6PO7zeqGKssg=="
     },
     "promise-to-callback": {
       "version": "1.0.0",
@@ -3290,11 +3682,6 @@
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
       "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
     },
-    "pseudomap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
-    },
     "psl": {
       "version": "1.1.29",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
@@ -3305,25 +3692,51 @@
       "resolved": "https://registry.npmjs.org/pull-defer/-/pull-defer-0.2.3.tgz",
       "integrity": "sha512-/An3KE7mVjZCqNhZsr22k1Tx8MACnUnHZZNPSJ0S62td8JtYr/AiRG42Vz7Syu31SoTLUzVIe61jtT/pNdjVYA=="
     },
-    "pull-pushable": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/pull-pushable/-/pull-pushable-2.2.0.tgz",
-      "integrity": "sha1-Xy867UethpGfAbEqLpnW8b13ZYE="
-    },
     "pull-stream": {
-      "version": "3.6.9",
-      "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.9.tgz",
-      "integrity": "sha512-hJn4POeBrkttshdNl0AoSCVjMVSuBwuHocMerUdoZ2+oIUzrWHFTwJMlbHND7OiKLVgvz6TFj8ZUVywUMXccbw=="
+      "version": "3.6.14",
+      "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.14.tgz",
+      "integrity": "sha512-KIqdvpqHHaTUA2mCYcLG1ibEbu/LCKoJZsBWyv9lSYtPkJPBq8m3Hxa103xHi6D2thj5YXa0TqK3L3GUkwgnew=="
     },
-    "pull-stream-to-stream": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/pull-stream-to-stream/-/pull-stream-to-stream-1.3.4.tgz",
-      "integrity": "sha1-P4HYIWvRjSv9GhmBkEcRgOJzg5k="
+    "pull-stream-to-async-iterator": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pull-stream-to-async-iterator/-/pull-stream-to-async-iterator-1.0.2.tgz",
+      "integrity": "sha512-c3KRs2EneuxP7b6pG9fvQTIjatf33RbIErhbQ75s5r2MI6E8R74NZC1nJgXc8kcmqiQxmr+TWY+WwK2mWaUnlA==",
+      "requires": {
+        "pull-stream": "^3.6.9"
+      }
     },
-    "pull-traverse": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/pull-traverse/-/pull-traverse-1.0.3.tgz",
-      "integrity": "sha1-dPtde+f6a9enjpeTPhmbeUWGaTg="
+    "pull-to-stream": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/pull-to-stream/-/pull-to-stream-0.1.1.tgz",
+      "integrity": "sha512-thZkMv6F9PILt9zdvpI2gxs19mkDrlixYKX6cOBxAW16i1NZH+yLAmF4r8QfJ69zuQh27e01JZP9y27tsH021w==",
+      "requires": {
+        "readable-stream": "^3.1.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
+        }
+      }
     },
     "pump": {
       "version": "3.0.0",
@@ -3741,17 +4154,37 @@
       "integrity": "sha512-TfOfPcYGBB5sDuPn3deByxPhmfegAhpDYKSOXZQN81Oyrrif8ZCodOLzK3AesELnCx03kikhyDwh0pfvvQvF8w=="
     },
     "split2": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
-      "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-3.1.1.tgz",
+      "integrity": "sha512-emNzr1s7ruq4N+1993yht631/JH+jaj0NYBosuKmLcq+JkGQ9MmTw1RB1fGaTCzUuseRIClrlSLHRNYGwWQ58Q==",
       "requires": {
-        "through2": "^2.0.2"
+        "readable-stream": "^3.0.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
+        }
       }
-    },
-    "sprintf-js": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.0.tgz",
-      "integrity": "sha1-z/yvcC2vZeo5u04PorKZzsGhvkY="
     },
     "sshpk": {
       "version": "1.15.1",
@@ -3774,50 +4207,14 @@
       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
       "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w=="
     },
-    "stream-http": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-3.0.0.tgz",
-      "integrity": "sha512-JELJfd+btL9GHtxU3+XXhg9NLYrKFnhybfvRuDghtyVkOFydz3PKNT1df07AMr88qW03WHF+FSV0PySpXignCA==",
-      "requires": {
-        "builtin-status-codes": "^3.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^3.0.6",
-        "xtend": "^4.0.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.0.6.tgz",
-          "integrity": "sha512-9E1oLoOWfhSXHGv6QlwXJim7uNzd9EVlWK+21tCU9Ju/kR0/p2AZYPz4qSchgO8PlLIH4FpZYfzwS+rEksZjIg==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
-      }
-    },
     "stream-to-pull-stream": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/stream-to-pull-stream/-/stream-to-pull-stream-1.7.2.tgz",
-      "integrity": "sha1-dXYJrhzr0zx0MtSvvjH/eGULnd4=",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/stream-to-pull-stream/-/stream-to-pull-stream-1.7.3.tgz",
+      "integrity": "sha512-6sNyqJpr5dIOQdgNy/xcDWwDuzAsAwVzhzrWlAPAQ7Lkjx/rv0wgvxEyKwTq6FmNd5rjTrELt/CLmaSw7crMGg==",
       "requires": {
         "looper": "^3.0.0",
         "pull-stream": "^3.2.3"
       }
-    },
-    "streamifier": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/streamifier/-/streamifier-0.1.1.tgz",
-      "integrity": "sha1-l+mNj6TRBdYqJpHR3AfoINuN/E8="
     },
     "string-width": {
       "version": "1.0.2",
@@ -3904,26 +4301,46 @@
       }
     },
     "tar-stream": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
-      "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.0.tgz",
+      "integrity": "sha512-+DAn4Nb4+gz6WZigRzKEZl1QuJVOLtAwwF+WUxy1fJ6X63CaGaUAxJRD2KEn1OMfcbCjySTYpNC6WmfQoIEOdw==",
       "requires": {
-        "bl": "^1.0.0",
-        "buffer-alloc": "^1.2.0",
-        "end-of-stream": "^1.0.0",
+        "bl": "^3.0.0",
+        "end-of-stream": "^1.4.1",
         "fs-constants": "^1.0.0",
-        "readable-stream": "^2.3.0",
-        "to-buffer": "^1.1.1",
-        "xtend": "^4.0.0"
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
       },
       "dependencies": {
         "bl": {
-          "version": "1.2.2",
-          "resolved": "http://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
-          "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-3.0.0.tgz",
+          "integrity": "sha512-EUAyP5UHU5hxF8BPT0LKW8gjYLhq1DQIcneOX/pL/m2Alo+OYDQAJlHq+yseMP50Os2nHXOSic6Ss3vSQeyf4A==",
           "requires": {
-            "readable-stream": "^2.3.5",
-            "safe-buffer": "^5.1.1"
+            "readable-stream": "^3.0.1"
+          }
+        },
+        "readable-stream": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+          "requires": {
+            "safe-buffer": "~5.2.0"
           }
         }
       }
@@ -3934,18 +4351,12 @@
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-      "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
+      "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
       "requires": {
-        "readable-stream": "^2.1.5",
-        "xtend": "~4.0.1"
+        "readable-stream": "2 || 3"
       }
-    },
-    "to-buffer": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
-      "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg=="
     },
     "to-fast-properties": {
       "version": "1.0.3",
@@ -3960,11 +4371,6 @@
         "psl": "^1.1.24",
         "punycode": "^1.4.1"
       }
-    },
-    "traverse": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
-      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
     },
     "trim": {
       "version": "0.0.1",
@@ -4158,10 +4564,15 @@
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
-    "typedarray": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    "unique-by": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unique-by/-/unique-by-1.0.0.tgz",
+      "integrity": "sha1-UiDIa6e8Vy+3E610ZRRwy2RCEr0="
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
     "unorm": {
       "version": "1.4.1",
@@ -4169,13 +4580,27 @@
       "integrity": "sha1-NkIA1fE2RsqLzURJAnEzVhR5IwA="
     },
     "ursa-optional": {
-      "version": "0.9.9",
-      "resolved": "https://registry.npmjs.org/ursa-optional/-/ursa-optional-0.9.9.tgz",
-      "integrity": "sha512-zEXexF6kK+MXbPO4PCSNZXD1bQNImKDkTVgGLFTMO7hvfbEmX4s6KwXla6VZm4eFua7hUiEH+gqsx11+ryYLpg==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/ursa-optional/-/ursa-optional-0.10.1.tgz",
+      "integrity": "sha512-/pgpBXVJut57dHNrdGF+1/qXi+5B7JrlmZDWPSyoivEcbwFWRZJBJGkWb6ivknMBA3bnFA7lqsb6iHiFfp79QQ==",
       "requires": {
-        "bindings": "^1.3.0",
-        "nan": "^2.11.1",
-        "which": "^1.3.1"
+        "bindings": "^1.5.0",
+        "nan": "^2.14.0"
+      },
+      "dependencies": {
+        "bindings": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+          "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+          "requires": {
+            "file-uri-to-path": "1.0.0"
+          }
+        },
+        "nan": {
+          "version": "2.14.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+          "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+        }
       }
     },
     "utf8": {
@@ -4222,7 +4647,7 @@
       "resolved": "http://registry.npmjs.org/web3/-/web3-0.20.6.tgz",
       "integrity": "sha1-PpcwauAk+yThCj11yIQwJWIhUSA=",
       "requires": {
-        "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git",
+        "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
         "crypto-js": "^3.1.4",
         "utf8": "^2.1.1",
         "xhr2": "*",
@@ -4259,7 +4684,7 @@
           "resolved": "https://registry.npmjs.org/web3/-/web3-0.16.0.tgz",
           "integrity": "sha1-pFVBdc1GKUMDWx8dOUMvdBxrYBk=",
           "requires": {
-            "bignumber.js": "git+https://github.com/debris/bignumber.js.git#master",
+            "bignumber.js": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
             "crypto-js": "^3.1.4",
             "utf8": "^2.1.1",
             "xmlhttprequest": "*"
@@ -4273,22 +4698,10 @@
         }
       }
     },
-    "webcrypto-shim": {
-      "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8",
-      "from": "github:dignifiedquire/webcrypto-shim#master"
-    },
     "whatwg-fetch": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
       "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
-    },
-    "which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "requires": {
-        "isexe": "^2.0.0"
-      }
     },
     "which-module": {
       "version": "1.0.0",
@@ -4351,9 +4764,9 @@
       "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
     },
     "yallist": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
     "yargs": {
       "version": "4.8.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@aragon/os": "^4.0.0",
     "axios": "^0.18.0",
     "ethjs-ens": "^2.0.1",
-    "ipfs-api": "^26.1.2",
+    "ipfs-http-client": "^39.0.2",
     "semver": "^5.5.0"
   }
 }

--- a/src/providers/ipfs.js
+++ b/src/providers/ipfs.js
@@ -1,4 +1,4 @@
-const ipfsAPI = require('ipfs-api')
+const ipfsAPI = require('ipfs-http-client')
 const httpProvider = require('./http')()
 
 module.exports = (opts = {}) => {
@@ -28,7 +28,7 @@ module.exports = (opts = {}) => {
         ipfs = initIPFS(opts)
       }
 
-      return ipfs.files.cat(`${hash}/${path}`)
+      return ipfs.cat(`${hash}/${path}`)
         .then((file) => file.toString('utf8'))
     },
 
@@ -48,7 +48,7 @@ module.exports = (opts = {}) => {
         ipfs = initIPFS(opts)
       }
 
-      return ipfs.files.catReadableStream(`${hash}/${path}`)
+      return ipfs.catReadableStream(`${hash}/${path}`)
     },
 
     /**
@@ -62,7 +62,7 @@ module.exports = (opts = {}) => {
         ipfs = initIPFS(opts)
       }
 
-      const hashes = await ipfs.util.addFromFs(path, { recursive: true })
+      const hashes = await ipfs.addFromFs(path, { recursive: true })
       const { hash } = hashes.pop()
 
       return `ipfs:${hash}`


### PR DESCRIPTION
`ipfs-api` was renamed to `ipfs-http-client` and has been deprecated for over a year now. This PR switches to using `ipfs-http-client` and updates the code to match changes in the API. There's no tests so hopefully this works!