### PR TITLE
Fix timeout leak bug only by cancelling the timeout on success

### DIFF
--- a/src/utils/timeout-promise.js
+++ b/src/utils/timeout-promise.js
@@ -1,16 +1,19 @@
 // https://italonascimento.github.io/applying-a-timeout-to-your-promises/
 module.exports = function(promise, ms) {
-
   // Create a promise that rejects in <ms> milliseconds
+  let timeoutInstance;
   const timeout = new Promise((resolve, reject) => {
-    const id = setTimeout(() => {
-      reject('Timed out in '+ ms + 'ms.')
-    }, ms)
-  })
+    timeoutInstance = setTimeout(() => {
+      reject(Error("Timed out in " + ms + "ms."));
+    }, ms);
+  });
 
   // Returns a race between our timeout and the passed in promise
-  return Promise.race([
-    promise,
-    timeout
-  ])
-}
+  return Promise.race([promise, timeout]).then(res => {
+    clearTimeout(timeoutInstance);
+    return res;
+  }).catch(e => {
+    clearTimeout(timeoutInstance);
+    throw e
+  })
+};


### PR DESCRIPTION
The smallest change to fix an immediate necessity for the aragonCLI refactor.

If possible I would advise using a more lengthy but proper solution https://github.com/aragon/apm.js/pull/44 over this one.